### PR TITLE
chore: app targets

### DIFF
--- a/Sources/ios-interview-test/App.swift
+++ b/Sources/ios-interview-test/App.swift
@@ -1,0 +1,55 @@
+//
+//  App.swift
+//  ios-interview-test
+//
+//  Created by Antoine Baché on 07/08/2022.
+//  Copyright © 2022 Ten Ten. All rights reserved.
+//
+import SwiftUI
+
+import Settings
+
+/// **Important:** You must not change the content of this file.
+@main
+struct TestApp: App {
+  var body: some Scene {
+    WindowGroup {
+      AppView.buildFromLaunchArguments()
+    }
+  }
+}
+
+private enum AppView: View {
+  case `default`
+  case friendlist
+  case settings
+
+  static func buildFromLaunchArguments() -> Self {
+    if LaunchArguments.showFriendlist {
+      return .friendlist
+    } else if LaunchArguments.showSettings {
+      return .settings
+    }
+
+    return .default
+  }
+}
+
+private extension AppView {
+  @ViewBuilder
+  var body: some View {
+    switch self {
+    case .default:
+      MainView()
+    case .friendlist:
+      FriendListView()
+    case .settings:
+      SettingsView()
+    }
+  }
+}
+
+private enum LaunchArguments {
+  static let showFriendlist = ProcessInfo.processInfo.arguments.contains("friendlist")
+  static let showSettings = ProcessInfo.processInfo.arguments.contains("settings")
+}

--- a/Sources/ios-interview-test/BUILD
+++ b/Sources/ios-interview-test/BUILD
@@ -1,5 +1,6 @@
-load("@build_bazel_rules_apple//apple:ios.bzl", "ios_framework")
+load("@build_bazel_rules_apple//apple:ios.bzl", "ios_application")
 load("@build_bazel_rules_swift//swift:swift.bzl", "swift_library")
+load("@build_bazel_rules_apple//apple:versioning.bzl", "apple_bundle_version")
 load(
     "@//build-system/apple-utils:plist_fragment.bzl",
     "plist_fragment",
@@ -18,21 +19,65 @@ swift_library(
     ]
 )
 
-ios_framework(
+ios_application(
     name = "ios-interview-test",
-    bundle_id = "com.tenten.interview.test",
+    bundle_id = "com.tenten.technical-test",
+    families = ["iphone"],
     infoplists = [":Info"],
     minimum_os_version = "15.4",
-    families = ["iphone"],
+    version = ":Version",
     deps = [":ios-interview-test-lib"],
     visibility = ["//visibility:public"],
 )
 
+apple_bundle_version(
+    name = "Version",
+    build_version = "1",
+    short_version_string = "0.0.1",
+)
+
 INFO_PLIST_TEMPLATE = """
-    <key>CFBundleIdentifier</key>
-    <string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
-    <key>CFBundleDevelopmentRegion</key>
-    <string>en</string>
+	<key>UIStatusBarStyle</key>
+	<string>UIStatusBarStyleLightContent</string>
+	<key>CADisableMinimumFrameDurationOnPhone</key>
+	<true/>
+	<key>CFBundleAllowMixedLocalizations</key>
+	<true/>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
+	<key>ITSAppUsesNonExemptEncryption</key>
+	<false/>
+	<key>LSRequiresIPhoneOS</key>
+	<true/>
+	<key>UIApplicationSceneManifest</key>
+	<dict>
+		<key>UIApplicationSupportsMultipleScenes</key>
+		<false/>
+	</dict>
+	<key>UIApplicationSupportsIndirectInputEvents</key>
+	<true/>
+	<key>UILaunchStoryboardName</key>
+	<string>Launch Screen</string>
+	<key>UIRequiredDeviceCapabilities</key>
+	<array>
+		<string>arm64</string>
+	</array>
+	<key>UISupportedInterfaceOrientations</key>
+	<array>
+		<string>UIInterfaceOrientationPortrait</string>
+	</array>
+	<key>UIViewControllerBasedStatusBarAppearance</key>
+	<false/>
 """
 
 plist_fragment(

--- a/Sources/ios-interview-test/FriendListCheck.swift
+++ b/Sources/ios-interview-test/FriendListCheck.swift
@@ -10,10 +10,16 @@ import SwiftUI
 
 import FriendList
 
+struct FriendListView: View {
+  var body: some View {
+    FriendListScreen.mocked()
+  }
+}
+
 /// **Important:** You must not change the content of this file.
 
 struct FriendList_Previews: PreviewProvider {
   static var previews: some View {
-    FriendListScreen.mocked()
+    FriendListView()
   }
 }

--- a/Sources/ios-interview-test/SettingsCheck.swift
+++ b/Sources/ios-interview-test/SettingsCheck.swift
@@ -10,15 +10,21 @@ import SwiftUI
 
 import Settings
 
-/// **Important:** You must not change the content of this file.
-
-struct Settings_Previews: PreviewProvider {
-  static var previews: some View {
+struct SettingsView: View {
+  var body: some View {
     SettingsScreen(user: UserModel(
       firstName: "Antoine",
       familyName: "Baché",
       status: "Just checking things out",
       joinedAt: Date(timeIntervalSince1970: 1_660_499_541)
     ))
+  }
+}
+
+/// **Important:** You must not change the content of this file.
+
+struct Settings_Previews: PreviewProvider {
+  static var previews: some View {
+    SettingsView()
   }
 }


### PR DESCRIPTION
Some candidates had issues using Xcode Previews.
Add Targets to be able to run as apps directly.
